### PR TITLE
同じ検索結果が出力されるのを一つずつにする

### DIFF
--- a/front/src/pages/top.tsx
+++ b/front/src/pages/top.tsx
@@ -35,7 +35,14 @@ export function TopPage(): JSX.Element {
     const filteredFaqs = faqs.filter((faq: FAQ) =>
       faq.question.toLowerCase().includes(e.target.value.toLowerCase()),
     );
-    setFaqs(filteredFaqs);
+    // uniqueFilteredFaqs pagetitleの異なるものをlist化
+    const uniqueFilteredFaqs: FAQ[] = [];
+    for (const filteredFaq of filteredFaqs) {
+      if (!uniqueFilteredFaqs.some((faq) => faq.pageTitle === filteredFaq.pageTitle)) {
+        uniqueFilteredFaqs.push(filteredFaq);
+      }
+    }
+    setFaqs(uniqueFilteredFaqs);
   };
 
   if (isLoading) {


### PR DESCRIPTION
検索結果のリンク先が同一の場合、まとめて1つにしてから表示する